### PR TITLE
Check for empty log streams list in tests

### DIFF
--- a/tests/shared-test-code/utils/aws/cloudWatchGetLogs.ts
+++ b/tests/shared-test-code/utils/aws/cloudWatchGetLogs.ts
@@ -65,6 +65,9 @@ const findMatchingLogEvents = async (
   logStreams: LogStream[],
   filterPatterns: string[]
 ) => {
+  if (logStreams.length < 1) {
+    return []
+  }
   return filterLogEvents({
     logGroupName: logGroupName,
     logStreamNames: logStreams.map(


### PR DESCRIPTION
The integration tests were failing when run against a freshly created stack (i.e. a feature stack in dev).
This was because they didn't cope with the situation of no log streams which we get right at the start before a Lambda has run for the first time.

This PR changes things so we simply return empty results to the caller if we attempt to search with an empty log stream list