### PR TITLE
TT2-1554 - remove custom kms encrpytion of test secrets manager

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1478,16 +1478,16 @@ Resources:
   IntegrationTestsNotifySecretSet:
     Condition: TestEnvironment
     Type: AWS::SecretsManager::Secret
+    # checkov:skip=CKV_AWS_149:"Ensure that Secrets Manager secret is encrypted using KMS CMK"
     Properties:
       Name: !Sub tests/${AWS::StackName}/NotifySecrets
-      KmsKeyId: '{{resolve:ssm:SecretsKmsKeyArn}}'
 
   IntegrationTestsZendeskecretSet:
     Condition: TestEnvironment
     Type: AWS::SecretsManager::Secret
+    # checkov:skip=CKV_AWS_149:"Ensure that Secrets Manager secret is encrypted using KMS CMK"
     Properties:
       Name: !Sub tests/${AWS::StackName}/ZendeskSecrets
-      KmsKeyId: '{{resolve:ssm:SecretsKmsKeyArn}}'
 
   SqsOperationsLambdaPolicy:
     Condition: TestRoleResources


### PR DESCRIPTION
- **Ticket Number**: #[1545](https://govukverify.atlassian.net/browse/TT2-1554) :ticket:

## :bulb: Description

after updating API key with a new key, the test container was unable to obtain secret due to custom kms key used by secrets manager. looking at event replay, its secrets are

1. in the config repo
2. doesnt use a custom KMS key 

so i've updated the secret to not use a custom kms key, this should allow the pipeline to run

## :sparkles: Changes Made

- remove custom kms key for test secrets and add a checkov ignore