### PR TITLE
map-athena-id-to-zendesk-in-logs

### DIFF
--- a/src/lambdas/sendQueryResultsNotification/handler.ts
+++ b/src/lambdas/sendQueryResultsNotification/handler.ts
@@ -20,11 +20,12 @@ export const handler = async (
   const athenaQueryId = queryDetails.queryExecutionId
 
   const requestData = await getQueryByAthenaQueryId(athenaQueryId)
+  const zendeskTicketId = requestData.requestInfo.zendeskId
+
+  appendZendeskIdToLogger(zendeskTicketId)
   logger.info('Retrieved request data from database by athenaQueryId', {
     athenaQueryId
   })
-  const zendeskTicketId = requestData.requestInfo.zendeskId
-  appendZendeskIdToLogger(zendeskTicketId)
 
   try {
     await confirmQueryState(queryDetails, zendeskTicketId)


### PR DESCRIPTION
tiny pr that re-orders the logging statement so we can map the athena query to a zendesk ticket