### PR TITLE
TT2-1977 Add alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# IntelliJ
+.idea/*

--- a/template.yaml
+++ b/template.yaml
@@ -1029,6 +1029,199 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt AthenaEBRule.Arn
 
+  ###################################
+  # Monitoring and Alerting Resources
+  ###################################
+
+  InitiateDataRequestLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref InitiateDataRequestLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'InitiateDataRequestLambdaMetric'
+
+  ProcessDataRequestLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref ProcessDataRequestLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'ProcessDataRequestLambdaMetric'
+
+  DataReadyForQueryLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref DataReadyForQueryLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'DataReadyForQueryLambdaMetric'
+
+  DecryptAndCopyLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref DecryptAndCopyLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'DecryptAndCopyLambdaMetric'
+
+  InitiateAthenaQueryLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref InitiateAthenaQueryLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'InitiateAthenaQueryLambdaMetric'
+
+  SendQueryResultsNotificationLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref SendQueryResultsNotificationLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'SendQueryResultsNotificationLambdaMetric'
+
+  CloseZendeskTicketLambdaFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      FilterPattern: '{ $.level = "ERROR" }'
+      LogGroupName: !Ref CloseZendeskTicketLogs
+      MetricTransformations:
+        - MetricValue: '1'
+          MetricNamespace: TxMA/TICFIntegration/Logs
+          MetricName: 'CloseZendeskTicketLambdaMetric'
+
+  InitiateDataRequestLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the InitiateDataRequestFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-initiate-data-request-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: InitiateDataRequestLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  ProcessDataRequestLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the ProcessDataRequestFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-process-data-request-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: ProcessDataRequestLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  DataReadyForQueryLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the DataReadyForQueryFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-data-ready-for-query-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: DataReadyForQueryLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  DecryptAndCopyLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the DecryptAndCopyFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-decrypt-and-copy-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: DecryptAndCopyLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  InitiateAthenaQueryLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the InitiateAthenaQueryFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-initiate-athena-query-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: InitiateAthenaQueryLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  SendQueryResultsNotificationLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the SendQueryResultsNotificationFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-send-query-results-notification-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: SendQueryResultsNotificationLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
+  CloseZendeskTicketLambdaAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: 'An alarm that is triggered by any error within the CloseZendeskTicketFunction lambda.'
+      AlarmName: !Sub ${AWS::StackName}-close-zendesk-ticket-lambda-alarm
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      DatapointsToAlarm: 1
+      EvaluationPeriods: 1
+      MetricName: CloseZendeskTicketLambdaMetric
+      Namespace: TxMA/TICFIntegration/Logs
+      Period: 3600
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: notBreaching
+
   ##################
   # Athena Resources
   ##################


### PR DESCRIPTION
Ticket Number: [TT2-1977](https://govukverify.atlassian.net/browse/TT2-1977)  🎫
Documentation Link(s): [Confluence](https://govukverify.atlassian.net/wiki/spaces/TMA/pages/4295360647/Lambdas+across+TxMA#Repo%3A-txma-ticf-integration) :books:

## :bulb: Description

Add alarms to lambdas as outlined in Confluence link. A separate PR will be needed to complete 1977 by adding canary deployments once we are happy with the alarms

## :sparkles: Changes Made

- Add IaC code for alarms

## :frame_with_picture: Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/529ade00-62d2-4bd9-a627-16cee1bf26a2)

## :white_tick: Documentation update

- Confluence link will need to be updated when this is merged

[TT2-1977]: https://govukverify.atlassian.net/browse/TT2-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ