### PR TITLE
TT2-1922 Externalise AWS SDK calls

### DIFF
--- a/src/lambdas/initiateAthenaQuery/startQueryExecution.ts
+++ b/src/lambdas/initiateAthenaQuery/startQueryExecution.ts
@@ -1,5 +1,4 @@
 import {
-  AthenaClient,
   StartQueryExecutionCommand,
   StartQueryExecutionCommandInput
 } from '@aws-sdk/client-athena'
@@ -7,19 +6,16 @@ import { logger } from '../../sharedServices/logger'
 import { CreateQuerySqlResult } from '../../types/athena/createQuerySqlResult'
 import { StartQueryExecutionResult } from '../../types/athena/startQueryExecutionResult'
 import { getEnv } from '../../utils/helpers'
+import { athenaClient } from '../../utils/awsSdkClients'
 
 export const startQueryExecution = async (
   queryParams: CreateQuerySqlResult
 ): Promise<StartQueryExecutionResult> => {
-  const client = new AthenaClient({
-    region: getEnv('AWS_REGION')
-  })
-
   const input = generateQueryExecutionCommandInput(queryParams)
   const command = new StartQueryExecutionCommand(input)
 
   try {
-    const response = await client.send(command)
+    const response = await athenaClient.send(command)
 
     if (!response.QueryExecutionId) {
       const error = new Error('Athena query execution id not found in response')

--- a/src/sharedServices/bulkJobs/describeBatchJob.ts
+++ b/src/sharedServices/bulkJobs/describeBatchJob.ts
@@ -1,16 +1,11 @@
-import {
-  DescribeJobCommand,
-  JobDescriptor,
-  S3ControlClient
-} from '@aws-sdk/client-s3-control'
+import { DescribeJobCommand, JobDescriptor } from '@aws-sdk/client-s3-control'
+import { s3ControlClient } from '../../utils/awsSdkClients'
 import { getEnv } from '../../utils/helpers'
 
 export const describeBatchJob = async (
   jobId: string
 ): Promise<JobDescriptor> => {
-  const client = new S3ControlClient({ region: getEnv('AWS_REGION') })
-
-  const response = await client.send(
+  const response = await s3ControlClient.send(
     new DescribeJobCommand({
       AccountId: getEnv('AWS_ACCOUNT_ID'),
       JobId: jobId

--- a/src/sharedServices/bulkJobs/getS3BatchJobTags.ts
+++ b/src/sharedServices/bulkJobs/getS3BatchJobTags.ts
@@ -1,16 +1,11 @@
-import {
-  GetJobTaggingCommand,
-  S3ControlClient,
-  S3Tag
-} from '@aws-sdk/client-s3-control'
+import { GetJobTaggingCommand, S3Tag } from '@aws-sdk/client-s3-control'
 import { getEnv } from '../../utils/helpers'
+import { s3ControlClient } from '../../utils/awsSdkClients'
 
 export const getS3BatchJobTags = async (
   jobId: string
 ): Promise<S3Tag[] | undefined> => {
-  const client = new S3ControlClient({ region: getEnv('AWS_REGION') })
-
-  const result = await client.send(
+  const result = await s3ControlClient.send(
     new GetJobTaggingCommand({
       AccountId: getEnv('AWS_ACCOUNT_ID'),
       JobId: jobId

--- a/src/sharedServices/bulkJobs/startGlacierRestore.ts
+++ b/src/sharedServices/bulkJobs/startGlacierRestore.ts
@@ -1,5 +1,4 @@
 import {
-  S3ControlClient,
   CreateJobCommand,
   CreateJobCommandInput
 } from '@aws-sdk/client-s3-control'
@@ -7,6 +6,7 @@ import { getEnv } from '../../utils/helpers'
 import { logger } from '../logger'
 import { getAuditDataSourceBucketName } from '../s3/getAuditDataSourceBucketName'
 import { writeJobManifestFileToJobBucket } from './writeJobManifestFileToJobBucket'
+import { s3ControlClient } from '../../utils/awsSdkClients'
 
 const analysisBucketName = getEnv('ANALYSIS_BUCKET_NAME')
 
@@ -40,7 +40,6 @@ const createBulkGlacierRestoreJob = async (
   manifestFileEtag: string,
   zendeskTicketId: string
 ): Promise<string | undefined> => {
-  const client = new S3ControlClient({ region: getEnv('AWS_REGION') })
   const input = {
     ConfirmationRequired: false,
     ClientRequestToken: `restore-${zendeskTicketId}`,
@@ -69,6 +68,6 @@ const createBulkGlacierRestoreJob = async (
       }
     }
   } as CreateJobCommandInput
-  const result = await client.send(new CreateJobCommand(input))
+  const result = await s3ControlClient.send(new CreateJobCommand(input))
   return result.JobId
 }

--- a/src/sharedServices/bulkJobs/startTransferToAnalysisBucket.ts
+++ b/src/sharedServices/bulkJobs/startTransferToAnalysisBucket.ts
@@ -1,5 +1,4 @@
 import {
-  S3ControlClient,
   CreateJobCommand,
   CreateJobCommandInput,
   JobReportScope
@@ -10,6 +9,7 @@ import { getEnv } from '../../utils/helpers'
 import { logger } from '../logger'
 import { getAuditDataSourceBucketName } from '../s3/getAuditDataSourceBucketName'
 import { writeJobManifestFileToJobBucket } from './writeJobManifestFileToJobBucket'
+import { s3ControlClient } from '../../utils/awsSdkClients'
 
 const analysisBucketName = getEnv('ANALYSIS_BUCKET_NAME')
 
@@ -50,7 +50,6 @@ const createS3TransferBatchJob = async (
   zendeskTicketId: string,
   decryptData: boolean
 ) => {
-  const client = new S3ControlClient({ region: getEnv('AWS_REGION') })
   const input = {
     ConfirmationRequired: false,
     AccountId: getEnv('AWS_ACCOUNT_ID'),
@@ -100,6 +99,6 @@ const createS3TransferBatchJob = async (
       }
     }
   } as CreateJobCommandInput
-  const result = await client.send(new CreateJobCommand(input))
+  const result = await s3ControlClient.send(new CreateJobCommand(input))
   return result.JobId
 }

--- a/src/sharedServices/bulkJobs/writeJobManifestFileToJobBucket.ts
+++ b/src/sharedServices/bulkJobs/writeJobManifestFileToJobBucket.ts
@@ -1,18 +1,18 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { PutObjectCommand } from '@aws-sdk/client-s3'
 import { getEnv } from '../../utils/helpers'
 import { logger } from '../logger'
 import { createManifestFileText } from './createManifestFileText'
+import { s3Client } from '../../utils/awsSdkClients'
 
 export const writeJobManifestFileToJobBucket = async (
   sourceBucket: string,
   fileList: string[],
   manifestFileName: string
 ): Promise<string> => {
-  const client = new S3Client(getEnv('AWS_REGION'))
   logger.info('Writing job manifest file', {
     manifestFileName: manifestFileName
   })
-  const response = await client.send(
+  const response = await s3Client.send(
     new PutObjectCommand({
       Key: manifestFileName,
       Bucket: getEnv('BATCH_JOB_MANIFEST_BUCKET_NAME'),

--- a/src/sharedServices/dynamoDB/dynamoDBClient.ts
+++ b/src/sharedServices/dynamoDB/dynamoDBClient.ts
@@ -1,5 +1,0 @@
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
-import { getEnv } from '../../utils/helpers'
-
-const ddbClient = new DynamoDBClient({ region: getEnv('AWS_REGION') })
-export { ddbClient }

--- a/src/sharedServices/dynamoDB/dynamoDBGet.ts
+++ b/src/sharedServices/dynamoDB/dynamoDBGet.ts
@@ -6,7 +6,7 @@ import {
 import { isDataRequestParams } from '../../types/dataRequestParams'
 import { DataRequestDatabaseEntry } from '../../types/dataRequestDatabaseEntry'
 import { getEnv } from '../../utils/helpers'
-import { ddbClient } from './dynamoDBClient'
+import { ddbClient } from '../../utils/awsSdkClients'
 
 export const getDatabaseEntryByZendeskId = async (
   zendeskId: string

--- a/src/sharedServices/dynamoDB/dynamoDBPut.ts
+++ b/src/sharedServices/dynamoDB/dynamoDBPut.ts
@@ -2,7 +2,7 @@ import { AttributeValue, PutItemCommand } from '@aws-sdk/client-dynamodb'
 import { DataRequestParams } from '../../types/dataRequestParams'
 import { currentDateEpochSeconds } from '../../utils/currentDateEpochSeconds'
 import { getEnv } from '../../utils/helpers'
-import { ddbClient } from './dynamoDBClient'
+import { ddbClient } from '../../utils/awsSdkClients'
 
 export const addNewDataRequestRecord = (
   dataRequestParams: DataRequestParams,

--- a/src/sharedServices/dynamoDB/dynamoDBUpdate.ts
+++ b/src/sharedServices/dynamoDB/dynamoDBUpdate.ts
@@ -1,4 +1,4 @@
-import { ddbClient } from './dynamoDBClient'
+import { ddbClient } from '../../utils/awsSdkClients'
 import {
   UpdateItemCommand,
   UpdateItemCommandInput

--- a/src/sharedServices/queue/sendSqsMessage.ts
+++ b/src/sharedServices/queue/sendSqsMessage.ts
@@ -1,9 +1,5 @@
-import {
-  SQSClient,
-  SendMessageRequest,
-  SendMessageCommand
-} from '@aws-sdk/client-sqs'
-import { getEnv } from '../../utils/helpers'
+import { SendMessageRequest, SendMessageCommand } from '@aws-sdk/client-sqs'
+import { sqsClient } from '../../utils/awsSdkClients'
 
 export const sendSqsMessage = async (
   messageBody: object,
@@ -22,7 +18,6 @@ export const sendSqsMessageWithStringBody = async (
   queueUrl: string,
   delaySendInSeconds?: number
 ): Promise<string | undefined> => {
-  const client = new SQSClient({ region: getEnv('AWS_REGION') })
   const message: SendMessageRequest = {
     QueueUrl: queueUrl,
     MessageBody: messageBody
@@ -30,6 +25,6 @@ export const sendSqsMessageWithStringBody = async (
   if (delaySendInSeconds) {
     message.DelaySeconds = delaySendInSeconds
   }
-  const result = await client.send(new SendMessageCommand(message))
+  const result = await sqsClient.send(new SendMessageCommand(message))
   return result.MessageId
 }

--- a/src/sharedServices/s3/copyS3Object.ts
+++ b/src/sharedServices/s3/copyS3Object.ts
@@ -1,17 +1,11 @@
-import {
-  S3Client,
-  CopyObjectCommand,
-  CopyObjectCommandInput
-} from '@aws-sdk/client-s3'
-import { getEnv } from '../../utils/helpers'
+import { CopyObjectCommand, CopyObjectCommandInput } from '@aws-sdk/client-s3'
+import { s3Client } from '../../utils/awsSdkClients'
 
 export const copyS3Object = async (
   key: string,
   copySource: string,
   bucket: string
 ): Promise<void> => {
-  const s3Client = new S3Client({ region: getEnv('AWS_REGION') })
-
   const copyCommand: CopyObjectCommandInput = {
     Key: key,
     CopySource: copySource,

--- a/src/sharedServices/s3/getS3ObjectAsStream.ts
+++ b/src/sharedServices/s3/getS3ObjectAsStream.ts
@@ -1,23 +1,17 @@
-import {
-  S3Client,
-  GetObjectCommand,
-  GetObjectCommandInput
-} from '@aws-sdk/client-s3'
+import { GetObjectCommand, GetObjectCommandInput } from '@aws-sdk/client-s3'
 import { Readable } from 'stream'
-import { getEnv } from '../../utils/helpers'
+import { s3Client } from '../../utils/awsSdkClients'
 
 export const getS3ObjectAsStream = async (
   bucket: string,
   fileKey: string
 ): Promise<Readable> => {
-  const client = new S3Client({ region: getEnv('AWS_REGION') })
-
   const input = {
     Bucket: bucket,
     Key: fileKey
   } as GetObjectCommandInput
 
-  const { Body } = await client.send(new GetObjectCommand(input))
+  const { Body } = await s3Client.send(new GetObjectCommand(input))
 
   if (!(Body instanceof Readable)) {
     throw Error('Get S3 Object command did not return stream')

--- a/src/sharedServices/s3/listS3Files.ts
+++ b/src/sharedServices/s3/listS3Files.ts
@@ -1,18 +1,16 @@
 import {
-  S3Client,
   ListObjectsV2Command,
   ListObjectsV2CommandInput,
   _Object
 } from '@aws-sdk/client-s3'
-import { getEnv } from '../../utils/helpers'
+import { s3Client } from '../../utils/awsSdkClients'
 
 export const listS3Files = async (
   input: ListObjectsV2CommandInput,
   objects: _Object[] = []
 ): Promise<_Object[]> => {
-  const client = new S3Client({ region: getEnv('AWS_REGION') })
   const command = new ListObjectsV2Command(input)
-  const response = await client.send(command)
+  const response = await s3Client.send(command)
 
   if (!response.Contents) return []
 

--- a/src/sharedServices/s3/putS3Object.ts
+++ b/src/sharedServices/s3/putS3Object.ts
@@ -1,22 +1,16 @@
-import {
-  S3Client,
-  PutObjectCommand,
-  PutObjectCommandInput
-} from '@aws-sdk/client-s3'
-import { getEnv } from '../../utils/helpers'
+import { PutObjectCommand, PutObjectCommandInput } from '@aws-sdk/client-s3'
+import { s3Client } from '../../utils/awsSdkClients'
 
 export const putS3Object = async (
   bucket: string,
   fileKey: string,
   data: Buffer
 ): Promise<void> => {
-  const client = new S3Client({ region: getEnv('AWS_REGION') })
-
   const input = {
     Bucket: bucket,
     Key: fileKey,
     Body: data
   } as PutObjectCommandInput
 
-  await client.send(new PutObjectCommand(input))
+  await s3Client.send(new PutObjectCommand(input))
 }

--- a/src/sharedServices/s3/readS3DataToString.ts
+++ b/src/sharedServices/s3/readS3DataToString.ts
@@ -1,13 +1,12 @@
-import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { GetObjectCommand } from '@aws-sdk/client-s3'
 import consumers from 'stream/consumers'
 import { Readable } from 'stream'
-import { getEnv } from '../../utils/helpers'
+import { s3Client } from '../../utils/awsSdkClients'
 
 export const readS3DataToString = async (
   bucketName: string,
   fileKey: string
 ): Promise<string> => {
-  const s3Client = new S3Client({ region: getEnv('AWS_REGION') })
   const commandInput = {
     Bucket: bucketName,
     Key: fileKey

--- a/src/sharedServices/secrets/retrieveSecrets.ts
+++ b/src/sharedServices/secrets/retrieveSecrets.ts
@@ -1,19 +1,17 @@
 import {
-  SecretsManagerClient,
   GetSecretValueCommand,
   GetSecretValueCommandInput
 } from '@aws-sdk/client-secrets-manager'
-import { getEnv } from '../../utils/helpers'
+import { secretsManagerClient } from '../../utils/awsSdkClients'
 
 export const retrieveSecrets = async (
   secretId: string
 ): Promise<{ [key: string]: string }> => {
-  const client = new SecretsManagerClient({
-    region: getEnv('AWS_REGION')
-  })
   const command: GetSecretValueCommandInput = {
     SecretId: secretId
   }
-  const data = await client.send(new GetSecretValueCommand(command))
+  const data = await secretsManagerClient.send(
+    new GetSecretValueCommand(command)
+  )
   return JSON.parse(data.SecretString as string)
 }

--- a/src/utils/awsSdkClients.ts
+++ b/src/utils/awsSdkClients.ts
@@ -1,0 +1,19 @@
+import { getEnv } from '../utils/helpers'
+
+import { AthenaClient } from '@aws-sdk/client-athena'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { S3Client } from '@aws-sdk/client-s3'
+import { S3ControlClient } from '@aws-sdk/client-s3-control'
+import { SQSClient } from '@aws-sdk/client-sqs'
+import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager'
+
+export const athenaClient = new AthenaClient({ region: getEnv('AWS_REGION') })
+export const ddbClient = new DynamoDBClient({ region: getEnv('AWS_REGION') })
+export const s3Client = new S3Client({ region: getEnv('AWS_REGION') })
+export const s3ControlClient = new S3ControlClient({
+  region: getEnv('AWS_REGION')
+})
+export const sqsClient = new SQSClient({ region: getEnv('AWS_REGION') })
+export const secretsManagerClient = new SecretsManagerClient({
+  region: getEnv('AWS_REGION')
+})


### PR DESCRIPTION
- **Ticket Number**: #[TT2-1922] :ticket:

Refactor to instantiate a single S3 client and a single SQS client, and use them everywhere, rather than potentially creating a new client per call to the lambda.

Integration tests in a feature branch in the `di-txma-audit-dev` account fail, but they fail there for the main branch too.

<img width="1154" alt="image" src="https://github.com/user-attachments/assets/0752aeea-23e9-44b2-aa3c-3648b0591596">


[TT2-1922]: https://govukverify.atlassian.net/browse/TT2-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ